### PR TITLE
only unpacking tarball if jira is not running

### DIFF
--- a/jira/init.sls
+++ b/jira/init.sls
@@ -16,6 +16,7 @@ unpack-jira-tarball:
     - user: jira
     - group: root
     - options: z
+    - unless: jira-service
     - if_missing: {{ jira.prefix }}/atlassian-jira-software-{{ jira.version }}-standalone
     - runas: jira
     - keep: True


### PR DESCRIPTION
Trying to fix the jira restart problem by only unpacking tarball if jira is not running